### PR TITLE
Modify article and base index views to use classes

### DIFF
--- a/hexlet_django_blog/article/urls.py
+++ b/hexlet_django_blog/article/urls.py
@@ -1,7 +1,7 @@
 from django.urls import path
 
-from hexlet_django_blog.article import views
+from hexlet_django_blog.article.views import IndexView
 
 urlpatterns = [
-    path('', views.index),
+    path('', IndexView.as_view()),
 ]

--- a/hexlet_django_blog/article/views.py
+++ b/hexlet_django_blog/article/views.py
@@ -1,7 +1,9 @@
 from django.shortcuts import render
+from django.views import View
 
 
-def index(request):
-    return render(request, 'article/index.html', context={
-        'app': 'Article'
-    })
+class IndexView(View):
+    def get(self, request):
+        return render(request, 'article/index.html', context={
+            'app': 'Article'
+        })

--- a/hexlet_django_blog/urls.py
+++ b/hexlet_django_blog/urls.py
@@ -16,9 +16,10 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path, include
 from hexlet_django_blog import views
+from hexlet_django_blog.views import HomePageView
 
 urlpatterns = [
-    path('', views.index),
+    path('', HomePageView.as_view(template_name='index.html')),
     path('about/', views.about),
     path('article/', include('hexlet_django_blog.article.urls')),
     path("admin/", admin.site.urls),

--- a/hexlet_django_blog/views.py
+++ b/hexlet_django_blog/views.py
@@ -1,10 +1,14 @@
 from django.shortcuts import render
+from django.views.generic.base import TemplateView
 
 
-def index(request):
-    return render(request, 'index.html', context={
-        'who': 'World',
-    })
+class HomePageView(TemplateView):
+    template_name = 'index.html'
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context['who'] = 'World'
+        return context
 
 
 def about(request):


### PR DESCRIPTION
- Replace `hexlet_django_blog.article.views.index` with `IndexView` class
- Replace `hexlet_django_blog.views.index` with `HomePageView` class inherited by `TemplateView`