### PR TITLE
Add ability to work with articles via admin part

### DIFF
--- a/hexlet_django_blog/article/admin.py
+++ b/hexlet_django_blog/article/admin.py
@@ -1,3 +1,10 @@
 from django.contrib import admin
+from .models import Article
+from django.contrib.admin import DateFieldListFilter
 
-# Register your models here.
+
+@admin.register(Article)
+class ArticleAdmin(admin.ModelAdmin):
+    list_display = ('name', 'timestamp')
+    search_fields = ['name', 'body']
+    list_filter = (('timestamp', DateFieldListFilter),)

--- a/hexlet_django_blog/article/models.py
+++ b/hexlet_django_blog/article/models.py
@@ -10,3 +10,9 @@ class Article(Model):
     name = CharField(max_length=200)  # название статьи
     body = TextField()  # тело статьи
     timestamp = DateTimeField(auto_now_add=True)
+
+    def __repr__(self):
+        return f"{self.name}"
+
+    def __str__(self):
+        return self.__repr__()


### PR DESCRIPTION
The changes enable articles content modification via admin part

CHANGELOG:
- modify `hexlet-django-blog.article.models.py` to represent an article by its name
- modify `hexlet-django-blog.article.admin.py` to register `Article` model and add `ArticleAdmin` to enable searching by name and timestamp