### PR TITLE
Modify views to render the list of articles

### DIFF
--- a/hexlet_django_blog/article/views.py
+++ b/hexlet_django_blog/article/views.py
@@ -1,11 +1,13 @@
 from django.shortcuts import render
 from django.views import View
+from hexlet_django_blog.article.models import Article
 
 
 class IndexView(View):
-    def get(self, request):
+    def get(self, request, *args, **kwargs):
+        articles = Article.objects.all()[:15]
         return render(request, 'article/index.html', context={
-            'app': 'Article'
+            'articles': articles,
         })
 
 

--- a/hexlet_django_blog/templates/article/index.html
+++ b/hexlet_django_blog/templates/article/index.html
@@ -1,1 +1,9 @@
-<h1>This is {{ app }} app!</h1>
+{% extends "base.html" %}
+
+{% block content %}
+    <h1>Список статей</h1>
+    {% for article in articles %}
+        <h2>{{ article.name }}</h2>
+        <div>{{ article.body|slice:":200" }}</div>
+    {% endfor %}
+{% endblock %}

--- a/hexlet_django_blog/templates/index.html
+++ b/hexlet_django_blog/templates/index.html
@@ -1,1 +1,5 @@
+{% extends "base.html" %}
+
+{% block content %}
 <h1>Hello, {{ who }}!</h1>
+{% endblock %}

--- a/hexlet_django_blog/views.py
+++ b/hexlet_django_blog/views.py
@@ -11,7 +11,9 @@ class HomePageView(TemplateView):
         return context
 
     def get(self, request, *args, **kwargs):
-        return redirect('article', tags='python', article_id=42)
+        return render(request, 'index.html', context={
+            'who': 'World',
+        })
 
 
 def about(request):


### PR DESCRIPTION
CHANGELOG:
- modify `hexlet-django-blog.article.views.py` to get first 15 articles from the DB
- modify `hexlet-django-blog.templates.article.index.html` to allow all iterate over articles
- modify `hexlet-django-blog.templates.index.html` to iherit it from `abse.html`.
- modify `hexlet-django-blog.views.py` to replace redirect with main page with menu