### PR TITLE
Add new `ArticleView` to enable /article/id endpoint

### DIFF
--- a/hexlet_django_blog/article/urls.py
+++ b/hexlet_django_blog/article/urls.py
@@ -1,9 +1,14 @@
 from django.urls import path
 
-from hexlet_django_blog.article.views import IndexView, CustomView
+from hexlet_django_blog.article.views import (
+    IndexView,
+    CustomView,
+    ArticleView,
+)
 
 urlpatterns = [
-    path("<str:tags>/<int:article_id>/",
-         CustomView.as_view(), name='article'),
     path('', IndexView.as_view()),
+    path('<int:id>/', ArticleView.as_view(), name='article'),
+    path("<str:tags>/<int:article_id>/",
+         CustomView.as_view(), name='article_with_tag'),
 ]

--- a/hexlet_django_blog/article/views.py
+++ b/hexlet_django_blog/article/views.py
@@ -1,4 +1,4 @@
-from django.shortcuts import render
+from django.shortcuts import render, get_object_or_404
 from django.views import View
 from hexlet_django_blog.article.models import Article
 
@@ -8,6 +8,14 @@ class IndexView(View):
         articles = Article.objects.all()[:15]
         return render(request, 'article/index.html', context={
             'articles': articles,
+        })
+
+
+class ArticleView(View):
+    def get(self, request, *args, **kwargs):
+        article = get_object_or_404(Article, id=kwargs['id'])
+        return render(request, 'article/show.html', context={
+            'article': article,
         })
 
 

--- a/hexlet_django_blog/templates/article/index.html
+++ b/hexlet_django_blog/templates/article/index.html
@@ -3,7 +3,7 @@
 {% block content %}
     <h1>Список статей</h1>
     {% for article in articles %}
-        <h2>{{ article.name }}</h2>
+        <a href="{% url 'article' id=article.id %}">{{ article.name }}</a>
         <div>{{ article.body|slice:":200" }}</div>
     {% endfor %}
 {% endblock %}

--- a/hexlet_django_blog/templates/article/show.html
+++ b/hexlet_django_blog/templates/article/show.html
@@ -1,0 +1,6 @@
+{% extends "base.html" %}
+
+{% block content %}
+     <h1>{{ article.name }}</h1>
+    <div>{{ article.body }}</div>
+{% endblock %}


### PR DESCRIPTION
CHANGELOG:
- modify `hexlet-django-blog.article.urls.py` to enable getting an article by id
- modify `hexlet-django-blog.article.views.html` by adding `ArticleView`
- modify `hexlet-django-blog.templates.article.index.html` to link article name to its page
- add `hexlet-django-blog.templates.article.show.html` to render one article page